### PR TITLE
Sync the log redirection option in the help message and the man page

### DIFF
--- a/fswebcam.1
+++ b/fswebcam.1
@@ -64,7 +64,7 @@ Run in the background. In this mode \fIstdout\fR and console logging are unavail
 Saves the PID of the background process to the specified file. Ignored when not using background mode.
 
 .TP
-\fB\-\-log\fR \fI[file/syslog:]<filename>\fR
+\fB\-L\fR, \fB\-\-log\fR \fI[file/syslog:]<filename>\fR
 Redirect log messages to a file or syslog. For example
 .IP
 \-\-log output.log

--- a/fswebcam.c
+++ b/fswebcam.c
@@ -1087,7 +1087,6 @@ int fswc_usage()
 	       " -b, --background             Run in the background.\n"
 	       "     --pid <filename>         Saves background process PID to filename.\n"
 	       " -L, --log [file/syslog:]<filename> Redirect log messages to a file or syslog.\n"
-	       " -o, --output <filename>      Output the log to a file.\n"
 	       " -d, --device <name>          Sets the source to use.\n"
 	       " -i, --input <number/name>    Selects the input to use.\n"
 	       "     --list-inputs            Displays available inputs.\n"


### PR DESCRIPTION
Remove the redundant -o / --output flag from the help message, and add the -L flag to the --log section of the man page.

This close #19 