### PR TITLE
Ability to build snap of fswebcam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ config.log
 config.status
 *.cache
 
+/parts/
+/prime/
+/stage/
+*.snap

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,12 +1,15 @@
 name: fswebcam  # the name of the snap
-version: 0  # the version of the snap
+version: 1  # the version of the snap
 summary: Snap of fswebcam  # 79 char long summary
 description: Snap of fswebcam  # a longer description for the snap
-confinement: devmode  # use "strict" to enforce system access only via declared interfaces
+confinement: strict  # use "strict" to enforce system access only via declared interfaces
 
 apps:
   fswebcam:
     command: fswebcam
+    plugs:
+      - home
+      - camera
 
 parts:
     fswebcam:  # Replace with a part name of your liking

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: fswebcam  # the name of the snap
+version: 0  # the version of the snap
+summary: Snap of fswebcam  # 79 char long summary
+description: Snap of fswebcam  # a longer description for the snap
+confinement: devmode  # use "strict" to enforce system access only via declared interfaces
+
+apps:
+  fswebcam:
+    command: fswebcam
+
+parts:
+    fswebcam:  # Replace with a part name of your liking
+        # Get more information about plugins by running
+        # snapcraft help plugins
+        # and more information about the available plugins
+        # by running
+        # snapcraft list-plugins
+        plugin: autotools
+        source: .
+        build-packages:
+          # Here for the plugins-- they're not linked in automatically.
+          - libgd-dev
+          - libgd3
+        stage-packages:
+          # Here for the plugins-- they're not linked in automatically.
+          - libgd3
+        


### PR DESCRIPTION
snapcraft.yaml added for producing snap of fswebcam

Using the Snapcraft packaging tool for snappy and the snapcraft.yaml file you can
now build an fswebcam snap and install on any OS with snappy installed.
See http://snapcraft.io/ for more details on snappy.

I have pushed the resulting snap to the snap store - https://myapps.developer.ubuntu.com/dev/click-apps/5794/ . I am currently the owner of that snap but I am happy to transfer to you. 

Steps to install from store:
$ sudo snap login %YOURLAUNCHPADUSERSEMAILADDRESS%
$ snap install fswebcam
$ sudo snap connect fswebcam:camera ubuntu-core:camera

Steps to build and install from local:
$ sudo apt install snapcraft
$ git clone git@github.com:philroche/fswebcam.git
$ git checkout snap
$ snapcraft
$ snapcraft install fswebcam_0_amd64.snap --devmode
$ /snap/bin/fswebcam photo.jpg
