### PR TITLE
V4L2 frame buffer length fix + extra option for faster stdout frame dump

### DIFF
--- a/src_v4l2.c
+++ b/src_v4l2.c
@@ -949,7 +949,7 @@ static int src_v4l2_grab(src_t *src)
 		}
 		
 		src->img    = s->buffer[s->buf.index].start;
-		src->length = s->buffer[s->buf.index].length;
+		src->length = s->buf.bytesused;
 		
 		s->pframe = s->buf.index;
 	}


### PR DESCRIPTION
While attempting some integration of fswebcam in a raspberry Pi based project I became interested in a faster way to grab a raw frame dump (no transcoding, no processing, just a fast raw dump from the device directly through stdout). The actual length of the data captured in the V4L2 buffer was the first issue identified. Additionally the need for an option to disable post processing was identified, but the attempted solution might not satisfy everyone.